### PR TITLE
增加一些直播相关功能

### DIFF
--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -43,6 +43,23 @@
       "params": null,
       "comment": "获取直播用户等级等信息"
     },
+    "user_guards": {
+      "url": "https://api.live.bilibili.com/xlive/web-ucenter/user/guards",
+      "method": "GET",
+      "verify": true,
+      "params": {
+        "page": "页码",
+        "page_size": "每页数量， 过多可能报错 默认：10"
+      },
+      "comment":　"获取用户开通的大航海列表"
+    },
+    "bag_list": {
+      "url": "https://api.live.bilibili.com/xlive/web-room/v1/gift/bag_list",
+      "method": "GET",
+      "verify": "true",
+      "params": null,
+      "comment": "获取自己的礼物包裹"
+    },
     "dahanghai": {
       "url": "https://api.live.bilibili.com/xlive/app-room/v1/guardTab/topList",
       "method": "GET",
@@ -54,6 +71,13 @@
         "page_size": 29
       },
       "comment": "获取大航海列表"
+    },
+    "live_info":{
+      "url": "https://api.live.bilibili.com/xlive/web-ucenter/user/live_info",
+      "method": "GET",
+      "verify": false,
+      "params": null,
+      "comment":"获取自己粉丝牌,大航海等数据"
     },
     "seven_rank": {
       "url": "https://api.live.bilibili.com/rankdb/v1/RoomRank/webSevenRank",
@@ -153,6 +177,46 @@
         "visit_id": "空"
       },
       "comment": "解封用户"
+    },
+    "dahanghai_sign_up": {
+      "url": "https://api.live.bilibili.com/xlive/activity-interface/v2/userTask/UserTaskSignUp",
+      "method":" POST",
+      "verify": true,
+      "params": {
+        "task_id": "任务id， 签到：1447 ，可能还有别的",
+        "r_uid": "房间真实id",
+        "csrf,csrf_token": "要给两个"
+      },
+      "comment": "航海日志签到"
+    },
+    "send_gift":{
+      "url": "https://api.live.bilibili.com/xlive/revenue/v1/gift/sendBag",
+      "method": "POST",
+      "verify": true,
+      "params": {
+        "uid": "自己的uid",
+        "bag_id": "包裹id",
+        "gift_id": "礼物id",
+        "gift_num": "发送数量",
+        "platform": "pc",
+        "send_ruid": "0 未知作用",
+        "storm_beat_id": "0 未知作用",
+        "price": "0 未知作用",
+        "biz_code": "live",
+        "biz_id": "room_display_id 房间显示id",
+        "ruid": "全称room_uid，从room_play_info里头的uid可以找到"
+      },
+      "comment": "在直播间中发送礼物"
+    },
+    "receive_reward":{
+      "url": "https://api.live.bilibili.com/xlive/activity-interface/v2/spec-act/sep-guard/receive/awards",
+      "method": "POST",
+      "verify": true,
+      "params": {
+        "ruid": "房间真实id",
+        "receive_type": "领取类型, 2为全部领取"
+      },
+      "comment": "领取航海日志奖励"
     }
   }
 }

--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -164,8 +164,8 @@
         "room_id": "显示房间号",
         "platform": "pc",
         "source": "live",
-        "area_id":"分区子id 可以不用填",
-        "area_parent_id":"分区父id 可以不用填, 获取分区id可使用 get_area_info 方法"
+        "area_id":"子分区id 可以不用填",
+        "area_parent_id":"父分区id 可以不用填, 获取分区id可使用 get_area_info 方法"
       },
       "comment": "获取该直播间通用礼物的信息，此api只返回gift_id ，不包含礼物price参数"
     },
@@ -179,8 +179,8 @@
         "source": "live",
         "tab_id": "礼物tab编号，2为特权礼物，3为定制礼物",
         "build": "未知作用， 默认1",
-        "area_id":"分区子id 可以不用填",
-        "area_parent_id":"分区父id 可以不用填, 获取分区id可使用 get_area_info 方法"
+        "area_id":"子分区id 可以不用填",
+        "area_parent_id":"父分区id 可以不用填, 获取分区id可使用 get_area_info 方法"
       },
       "comment": "获取该直播间特殊礼物的信息"
     },
@@ -192,8 +192,8 @@
         "room_id": "显示房间号 可以不用填",
         "platform": "pc",
         "source": "live",
-        "area_id": "分区子id 可以不用填",
-        "area_parent_id": "分区父id 可以不用填, 获取分区id可使用 get_area_info 方法"
+        "area_id": "子分区id 可以不用填",
+        "area_parent_id": "父分区id 可以不用填, 获取分区id可使用 get_area_info 方法"
       },
       "comment":"获取所有礼物信息，三个字段可以不用填，但填了有助于减小返回内容的大小，置空返回约2.7w行，填了三个对应值返回约1.4w行"
     }
@@ -254,14 +254,14 @@
       "method": "POST",
       "verify": true,
       "params": {
-        "uid": "送礼者的uid",
-        "bag_id": "包裹id",
+        "uid": "赠送用户的uid",
+        "bag_id": "礼物背id",
         "gift_id": "礼物id",
         "gift_num": "发送数量",
         "platform": "pc",
-        "send_ruid": "0 未知作用",
-        "storm_beat_id": "0 未知作用",
-        "price": "0 未知作用",
+        "send_ruid": "未知作用，默认：0",
+        "storm_beat_id": "未知作用，默认：0",
+        "price": "礼物单价， 背包中的礼物价值默认：0",
         "biz_code": "live",
         "biz_id": "room_display_id 房间显示id",
         "ruid": "全称 room_uid，从 room_play_info 里头的uid可以找到"
@@ -273,10 +273,10 @@
       "method": "POST",
       "verify": true,
       "params": {
-        "uid": "送礼者的uid",
+        "uid": "赠送用户的uid",
         "gift_id": "礼物id",
         "ruid":"全称 room_uid，从 room_play_info 里头的uid可以找到",
-        "send_ruid":"0 未知作用",
+        "send_ruid":"未知作用，默认：0",
         "gift_num": "发送数量",
         "coin_type": "gold",
         "bag_id": "0",
@@ -284,7 +284,7 @@
         "biz_code": "Live",
         "biz_id": "room_display_id 房间显示id",
         "rnd": "当前时间戳",
-        "storm_beat_id": "0 未知作用 可能是节奏风暴相关",
+        "storm_beat_id": "未知作用，默认：0",
         "price": "礼物单价",
         "csrf,csrf_token": "要给两个",
         "visit_id": "空"
@@ -299,7 +299,7 @@
         "uid": "送礼者的uid",
         "gift_id": "礼物id 辣条的id为1",
         "ruid":"全称 room_uid，从 room_play_info 里头的uid可以找到",
-        "send_ruid":"0 未知作用",
+        "send_ruid":"未知作用，默认：0",
         "gift_num": "发送数量",
         "coin_type": "silver",
         "bag_id": "0",
@@ -307,7 +307,7 @@
         "biz_code": "Live",
         "biz_id": "room_display_id 房间显示id",
         "rnd": "当前时间戳",
-        "storm_beat_id": "0 未知作用 可能是节奏风暴相关",
+        "storm_beat_id": "未知作用，默认：0",
         "price": "礼物单价 辣条单价为100",
         "csrf,csrf_token": "要给两个",
         "visit_id": "空"

--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -255,18 +255,19 @@
       "verify": true,
       "params": {
         "uid": "赠送用户的uid",
-        "bag_id": "礼物背id",
+        "bag_id": "礼物包裹的id",
         "gift_id": "礼物id",
-        "gift_num": "发送数量",
+        "gift_num": "赠送数量",
         "platform": "pc",
         "send_ruid": "未知作用，默认：0",
         "storm_beat_id": "未知作用，默认：0",
         "price": "礼物单价， 背包中的礼物价值默认：0",
         "biz_code": "live",
         "biz_id": "room_display_id 房间显示id",
-        "ruid": "全称 room_uid，从 room_play_info 里头的uid可以找到"
+        "ruid": "全称 room_uid，从 room_play_info 里头的uid可以找到",
+        "csrf,csrf_token": "要给两个"
       },
-      "comment": "在直播间中赠送包裹中的礼物"
+      "comment": "在直播间中赠送包裹中的礼物，包裹信息可用 get_self_bag 方法获取"
     },
     "send_gift_gold": {
       "url": "https://api.live.bilibili.com/xlive/revenue/v1/gift/sendGold",
@@ -277,7 +278,7 @@
         "gift_id": "礼物id",
         "ruid":"全称 room_uid，从 room_play_info 里头的uid可以找到",
         "send_ruid":"未知作用，默认：0",
-        "gift_num": "发送数量",
+        "gift_num": "赠送数量",
         "coin_type": "gold",
         "bag_id": "0",
         "platform": "pc",
@@ -286,8 +287,8 @@
         "rnd": "当前时间戳",
         "storm_beat_id": "未知作用，默认：0",
         "price": "礼物单价",
-        "csrf,csrf_token": "要给两个",
-        "visit_id": "空"
+        "visit_id": "空",
+        "csrf,csrf_token": "要给两个"
       },
       "comment": "在直播间中赠送金瓜子礼物"
     },
@@ -296,11 +297,11 @@
       "method": "POST",
       "verify": true,
       "params": {
-        "uid": "送礼者的uid",
+        "uid": "赠送用户的uid",
         "gift_id": "礼物id 辣条的id为1",
         "ruid":"全称 room_uid，从 room_play_info 里头的uid可以找到",
         "send_ruid":"未知作用，默认：0",
-        "gift_num": "发送数量",
+        "gift_num": "赠送数量",
         "coin_type": "silver",
         "bag_id": "0",
         "platform": "pc",
@@ -309,8 +310,8 @@
         "rnd": "当前时间戳",
         "storm_beat_id": "未知作用，默认：0",
         "price": "礼物单价 辣条单价为100",
-        "csrf,csrf_token": "要给两个",
-        "visit_id": "空"
+        "visit_id": "空",
+        "csrf,csrf_token": "要给两个"
       },
       "comment": "在直播间中赠送银瓜子礼物"
     },

--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -51,7 +51,7 @@
         "page": "页码",
         "page_size": "每页数量， 过多可能报错 默认：10"
       },
-      "comment":　"获取用户开通的大航海列表"
+      "comment": "获取用户开通的大航海列表"
     },
     "bag_list": {
       "url": "https://api.live.bilibili.com/xlive/web-room/v1/gift/bag_list",
@@ -77,17 +77,17 @@
       "method": "GET",
       "verify": false,
       "params": null,
-      "comment":"获取自己粉丝牌,大航海等数据"
+      "comment": "获取自己粉丝牌,大航海等数据"
     },
-    "general_info":{
+    "general_info": {
       "url": "https://api.live.bilibili.com/xlive/fuxi-interface/general/half/initial",
       "method": "GET",
       "verify": true,
       "params": {
-          "actId": "未知，大航海信息：100061",
-          "roomId": "真实房间号",
-          "uid": "直播者uid",
-          "csrf,csrf_token": "要给两个"
+        "actId": "未知，大航海信息：100061",
+        "roomId": "真实房间号",
+        "uid": "直播者uid",
+        "csrf,csrf_token": "要给两个"
       },
       "comment": "获取自己在当前房间的大航海信息, 是否开通，等级，当前经验，同时可获得自己开通的所有航海日志"
     },
@@ -192,7 +192,7 @@
     },
     "sign_up_dahanghai": {
       "url": "https://api.live.bilibili.com/xlive/activity-interface/v2/userTask/UserTaskSignUp",
-      "method":" POST",
+      "method": " POST",
       "verify": true,
       "params": {
         "task_id": "任务id， 签到：1447 ，可能还有别的",
@@ -201,7 +201,7 @@
       },
       "comment": "航海日志签到"
     },
-    "send_gift":{
+    "send_gift": {
       "url": "https://api.live.bilibili.com/xlive/revenue/v1/gift/sendBag",
       "method": "POST",
       "verify": true,
@@ -216,11 +216,11 @@
         "price": "0 未知作用",
         "biz_code": "live",
         "biz_id": "room_display_id 房间显示id",
-        "ruid": "全称room_uid，从room_play_info里头的uid可以找到"
+        "ruid": "全称 room_uid，从 room_play_info 里头的uid可以找到"
       },
       "comment": "在直播间中发送礼物"
     },
-    "receive_reward":{
+    "receive_reward": {
       "url": "https://api.live.bilibili.com/xlive/activity-interface/v2/spec-act/sep-guard/receive/awards",
       "method": "POST",
       "verify": true,

--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -72,12 +72,24 @@
       },
       "comment": "获取大航海列表"
     },
-    "live_info":{
+    "live_info": {
       "url": "https://api.live.bilibili.com/xlive/web-ucenter/user/live_info",
       "method": "GET",
       "verify": false,
       "params": null,
       "comment":"获取自己粉丝牌,大航海等数据"
+    },
+    "general_info":{
+      "url": "https://api.live.bilibili.com/xlive/fuxi-interface/general/half/initial",
+      "method": "GET",
+      "verify": true,
+      "params": {
+          "actId": "未知，大航海信息：100061",
+          "roomId": "真实房间号",
+          "uid": "直播者uid",
+          "csrf,csrf_token": "要给两个"
+      },
+      "comment": "获取自己在当前房间的大航海信息, 是否开通，等级，当前经验，同时可获得自己开通的所有航海日志"
     },
     "seven_rank": {
       "url": "https://api.live.bilibili.com/rankdb/v1/RoomRank/webSevenRank",
@@ -178,7 +190,7 @@
       },
       "comment": "解封用户"
     },
-    "dahanghai_sign_up": {
+    "sign_up_dahanghai": {
       "url": "https://api.live.bilibili.com/xlive/activity-interface/v2/userTask/UserTaskSignUp",
       "method":" POST",
       "verify": true,
@@ -214,7 +226,8 @@
       "verify": true,
       "params": {
         "ruid": "房间真实id",
-        "receive_type": "领取类型, 2为全部领取"
+        "receive_type": "领取类型， 全部领取：2",
+        "csrf,csrf_token": "要给两个"
       },
       "comment": "领取航海日志奖励"
     }

--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -36,6 +36,13 @@
       },
       "comment": "获取自己在直播间的信息（粉丝勋章等级，直播用户等级等）"
     },
+    "area_info": {
+      "url": "http://api.live.bilibili.com/room/v1/Area/getList",
+      "method": "GET",
+      "verify": false,
+      "params": null,
+      "comment": "获取直播间分区信息"
+    },
     "user_info": {
       "url": "https://api.live.bilibili.com/xlive/web-ucenter/user/get_user_info",
       "method": "GET",
@@ -148,6 +155,47 @@
         "ptype": "16"
       },
       "comment": "获取房间信息及可用清晰度列表"
+    },
+    "gift_common": {
+      "url": "https://api.live.bilibili.com/xlive/web-room/v1/giftPanel/giftData",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "room_id": "显示房间号",
+        "platform": "pc",
+        "source": "live",
+        "area_id":"分区子id 可以不用填",
+        "area_parent_id":"分区父id 可以不用填, 获取分区id可使用 get_area_info 方法"
+      },
+      "comment": "获取该直播间通用礼物的信息，此api只返回gift_id ，不包含礼物price参数"
+    },
+    "gift_special": {
+      "url": "https://api.live.bilibili.com//xlive/web-room/v1/giftPanel/tabRoomGiftList",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "room_id": "显示房间号",
+        "platform": "pc",
+        "source": "live",
+        "tab_id": "礼物tab编号，2为特权礼物，3为定制礼物",
+        "build": "未知作用， 默认1",
+        "area_id":"分区子id 可以不用填",
+        "area_parent_id":"分区父id 可以不用填, 获取分区id可使用 get_area_info 方法"
+      },
+      "comment": "获取该直播间特殊礼物的信息"
+    },
+    "gift_config":{
+      "url": "https://api.live.bilibili.com/xlive/web-room/v1/giftPanel/giftConfig",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "room_id": "显示房间号 可以不用填",
+        "platform": "pc",
+        "source": "live",
+        "area_id": "分区子id 可以不用填",
+        "area_parent_id": "分区父id 可以不用填, 获取分区id可使用 get_area_info 方法"
+      },
+      "comment":"获取所有礼物信息，三个字段可以不用填，但填了有助于减小返回内容的大小，置空返回约2.7w行，填了三个对应值返回约1.4w行"
     }
   },
   "operate": {
@@ -201,7 +249,7 @@
       },
       "comment": "航海日志签到"
     },
-    "send_gift": {
+    "send_gift_from_bag": {
       "url": "https://api.live.bilibili.com/xlive/revenue/v1/gift/sendBag",
       "method": "POST",
       "verify": true,
@@ -218,7 +266,53 @@
         "biz_id": "room_display_id 房间显示id",
         "ruid": "全称 room_uid，从 room_play_info 里头的uid可以找到"
       },
-      "comment": "在直播间中发送礼物"
+      "comment": "在直播间中赠送包裹中的礼物"
+    },
+    "send_gift_gold": {
+      "url": "https://api.live.bilibili.com/xlive/revenue/v1/gift/sendGold",
+      "method": "POST",
+      "verify": true,
+      "params": {
+        "uid": "送礼者的uid",
+        "gift_id": "礼物id",
+        "ruid":"全称 room_uid，从 room_play_info 里头的uid可以找到",
+        "send_ruid":"0 未知作用",
+        "gift_num": "发送数量",
+        "coin_type": "gold",
+        "bag_id": "0",
+        "platform": "pc",
+        "biz_code": "Live",
+        "biz_id": "room_display_id 房间显示id",
+        "rnd": "当前时间戳",
+        "storm_beat_id": "0 未知作用 可能是节奏风暴相关",
+        "price": "礼物单价",
+        "csrf,csrf_token": "要给两个",
+        "visit_id": "空"
+      },
+      "comment": "在直播间中赠送金瓜子礼物"
+    },
+    "send_gift_silver" :{
+      "url": "https://api.live.bilibili.com/xlive/revenue/v1/gift/sendSilver",
+      "method": "POST",
+      "verify": true,
+      "params": {
+        "uid": "送礼者的uid",
+        "gift_id": "礼物id 辣条的id为1",
+        "ruid":"全称 room_uid，从 room_play_info 里头的uid可以找到",
+        "send_ruid":"0 未知作用",
+        "gift_num": "发送数量",
+        "coin_type": "silver",
+        "bag_id": "0",
+        "platform": "pc",
+        "biz_code": "Live",
+        "biz_id": "room_display_id 房间显示id",
+        "rnd": "当前时间戳",
+        "storm_beat_id": "0 未知作用 可能是节奏风暴相关",
+        "price": "礼物单价 辣条单价为100",
+        "csrf,csrf_token": "要给两个",
+        "visit_id": "空"
+      },
+      "comment": "在直播间中赠送银瓜子礼物"
     },
     "receive_reward": {
       "url": "https://api.live.bilibili.com/xlive/activity-interface/v2/spec-act/sep-guard/receive/awards",

--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -196,7 +196,7 @@
       "verify": true,
       "params": {
         "task_id": "任务id， 签到：1447 ，可能还有别的",
-        "r_uid": "房间真实id",
+        "uid": "真实房间号",
         "csrf,csrf_token": "要给两个"
       },
       "comment": "航海日志签到"
@@ -206,7 +206,7 @@
       "method": "POST",
       "verify": true,
       "params": {
-        "uid": "自己的uid",
+        "uid": "送礼者的uid",
         "bag_id": "包裹id",
         "gift_id": "礼物id",
         "gift_num": "发送数量",

--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -192,7 +192,7 @@
     },
     "sign_up_dahanghai": {
       "url": "https://api.live.bilibili.com/xlive/activity-interface/v2/userTask/UserTaskSignUp",
-      "method": " POST",
+      "method": "POST",
       "verify": true,
       "params": {
         "task_id": "任务id， 签到：1447 ，可能还有别的",

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -324,6 +324,85 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
 
+    async def sign_up_dahanghai(self,task_id: int = 1447):
+        """
+        大航海签到
+
+        Args:
+            task_id (int, optional): 签到任务 ID. Defaults to 1447
+        """
+        self.credential.raise_for_no_sessdata()
+
+        api = API["operate"]["sign_up_dahanghai"]
+        data = {
+            "task_id": task_id,
+            "r_uid": await self.__get_ruid(),
+        }
+        return await request(api['method'], api["url"], data=data, credential=self.credential)
+
+    async def send_gift(self,uid: int, bag_id: int, gift_id: int, gift_num: int,platform: str="pc",send_ruid: int=0,storm_beat_id: int=0, price: int=0, biz_code: str="live"):
+        """
+        直播间发送礼物
+
+        Args:
+            uid (int)       : 用户 UID
+            bag_id (int)    : 礼物背包 ID
+            gift_id (int)   : 礼物 ID
+            gift_num (int)  : 礼物数量
+        """
+        self.credential.raise_for_no_sessdata()
+
+        api = API["operate"]["send_gift"]
+        data = {
+            "uid": uid,
+            "bag_id": bag_id,
+            "gift_id": gift_id,
+            "gift_num": gift_num,
+            "platform": platform,
+            "send_ruid": send_ruid,
+            "storm_beat_id": storm_beat_id,
+            "price": price,
+            "biz_code": biz_code,
+            "biz_id": self.room_display_id,
+            "r_uid": await self.__get_ruid(),
+
+        }
+        return await request(api['method'], api["url"], data=data, credential=self.credential)
+        
+    async def receive_reward(self, receive_type: int = 2):
+        """
+        领取自己在某个直播间的航海日志奖励
+
+        Args:
+            receive_type (int) : 领取类型，Defaults to 2
+        """
+        self.credential.raise_for_no_sessdata()
+
+        api = API["operate"]["receive_reward"]
+        data = {
+            "ruid": await self.__get_ruid(),
+            "receive_type": receive_type,
+        }
+        return await request(api['method'], api["url"], data=data, credential=self.credential)
+    
+    async def get_general_info(self, uid: int, actId: int = 100061):
+        """
+        获取自己在该房间的大航海信息, 比如是否开通, 等级等
+
+        Args:
+            uid (int)   : 直播者的用户id
+            actId (int) : 未知，Defaults to 100061
+
+        """
+        uid = (await self.get_room_play_info())["uid"]
+        api = API["info"]["get_general_info"]
+        params = {
+            "actId": actId,
+            "roomId": self.room_display_id,
+            "uid": uid
+        }
+        return await request(api['method'], api["url"], params=params, credential=self.credential)        
+
 
 class LiveDanmaku(AsyncEvent):
     """
@@ -677,4 +756,43 @@ async def get_self_info(credential: Credential):
     credential.raise_for_no_sessdata()
 
     api = API["info"]["user_info"]
+    return await request(api['method'], api["url"], credential=credential)
+
+async def get_self_live_info(credential: Credential):
+    """
+    获取自己的粉丝牌、大航海等信息
+    """
+
+    credential.raise_for_no_sessdata()
+
+    api = API["info"]["live_info"]
+    return await request(api['method'], api["url"], credential=credential)
+
+async def get_self_guards(credential: Credential, page: int = 1,page_size: int = 10):
+    """
+    获取自己开通的大航海信息
+
+    Args:
+        page (int, optional): 页数. Defaults to 1.
+        page_size (int, optional): 每页数量. Defaults to 10.
+
+    总页数取得方法:
+    >>> info = live.get_self_live_info(credential)
+        pages = math.ceil(info['data']['guards']/10)
+
+    """
+
+    credential.raise_for_no_sessdata()
+
+    api = API["info"]["user_guards"]
+    return await request(api['method'], api["url"], credential=credential)
+
+async def get_self_bag(credential: Credential):
+    """
+    获取自己的直播礼物包裹信息
+    """
+
+    credential.raise_for_no_sessdata()
+
+    api = API["info"]["bag_list"]
     return await request(api['method'], api["url"], credential=credential)

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -337,7 +337,7 @@ class LiveRoom:
         api = API["operate"]["sign_up_dahanghai"]
         data = {
             "task_id": task_id,
-            "r_uid": await self.__get_ruid(),
+            "uid": await self.__get_ruid(),
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
 
@@ -375,7 +375,7 @@ class LiveRoom:
             "price": price,
             "biz_code": biz_code,
             "biz_id": self.room_display_id,
-            "r_uid": await self.__get_ruid(),
+            "ruid": await self.__get_ruid(),
 
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -324,7 +324,7 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
 
-    async def sign_up_dahanghai(self,task_id: int = 1447):
+    async def sign_up_dahanghai(self, task_id: int = 1447):
         """
         大航海签到
 
@@ -332,6 +332,7 @@ class LiveRoom:
             task_id (int, optional): 签到任务 ID. Defaults to 1447
         """
         self.credential.raise_for_no_sessdata()
+        self.credential.raise_for_no_bili_jct()
 
         api = API["operate"]["sign_up_dahanghai"]
         data = {
@@ -340,7 +341,16 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
 
-    async def send_gift(self,uid: int, bag_id: int, gift_id: int, gift_num: int,platform: str="pc",send_ruid: int=0,storm_beat_id: int=0, price: int=0, biz_code: str="live"):
+    async def send_gift(self,
+                        uid: int,
+                        bag_id: int,
+                        gift_id: int,
+                        gift_num: int,
+                        platform: str = "pc",
+                        send_ruid: int = 0,
+                        storm_beat_id: int = 0,
+                        price: int = 0,
+                        biz_code: str = "live"):
         """
         直播间发送礼物
 
@@ -351,6 +361,7 @@ class LiveRoom:
             gift_num (int)  : 礼物数量
         """
         self.credential.raise_for_no_sessdata()
+        self.credential.raise_for_no_bili_jct()
 
         api = API["operate"]["send_gift"]
         data = {
@@ -368,7 +379,7 @@ class LiveRoom:
 
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
-        
+
     async def receive_reward(self, receive_type: int = 2):
         """
         领取自己在某个直播间的航海日志奖励
@@ -384,24 +395,24 @@ class LiveRoom:
             "receive_type": receive_type,
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
-    
-    async def get_general_info(self, uid: int, actId: int = 100061):
+
+    async def get_general_info(self, uid: int, act_id: int = 100061):
         """
         获取自己在该房间的大航海信息, 比如是否开通, 等级等
 
         Args:
             uid (int)   : 直播者的用户id
-            actId (int) : 未知，Defaults to 100061
+            act_id (int) : 未知，Defaults to 100061
 
         """
         uid = (await self.get_room_play_info())["uid"]
-        api = API["info"]["get_general_info"]
+        api = API["info"]["general_info"]
         params = {
-            "actId": actId,
+            "actId": act_id,
             "roomId": self.room_display_id,
             "uid": uid
         }
-        return await request(api['method'], api["url"], params=params, credential=self.credential)        
+        return await request(api['method'], api["url"], params=params, credential=self.credential)
 
 
 class LiveDanmaku(AsyncEvent):
@@ -758,6 +769,7 @@ async def get_self_info(credential: Credential):
     api = API["info"]["user_info"]
     return await request(api['method'], api["url"], credential=credential)
 
+
 async def get_self_live_info(credential: Credential):
     """
     获取自己的粉丝牌、大航海等信息
@@ -768,7 +780,8 @@ async def get_self_live_info(credential: Credential):
     api = API["info"]["live_info"]
     return await request(api['method'], api["url"], credential=credential)
 
-async def get_self_guards(credential: Credential, page: int = 1,page_size: int = 10):
+
+async def get_self_guards(credential: Credential, page: int = 1, page_size: int = 10):
     """
     获取自己开通的大航海信息
 
@@ -777,15 +790,22 @@ async def get_self_guards(credential: Credential, page: int = 1,page_size: int =
         page_size (int, optional): 每页数量. Defaults to 10.
 
     总页数取得方法:
-    >>> info = live.get_self_live_info(credential)
-        pages = math.ceil(info['data']['guards']/10)
 
+    ```python
+    info = live.get_self_live_info(credential)
+    pages = math.ceil(info['data']['guards'] / 10)
+    ```
     """
 
     credential.raise_for_no_sessdata()
 
     api = API["info"]["user_guards"]
-    return await request(api['method'], api["url"], credential=credential)
+    params = {
+        "page": page,
+        "page_size": page_size
+    }
+    return await request(api['method'], api["url"], params=params, credential=credential)
+
 
 async def get_self_bag(credential: Credential):
     """

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -158,7 +158,6 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], params, credential=self.credential)
 
-
     async def get_user_info_in_room(self):
         """
         获取自己在直播间的信息（粉丝勋章等级，直播用户等级等）
@@ -186,7 +185,6 @@ class LiveRoom:
             "page": page
         }
         return await request(api['method'], api["url"], params, credential=self.credential)
-
 
     async def get_seven_rank(self):
         """
@@ -267,7 +265,6 @@ class LiveRoom:
         }
         return await request(api['method'], api['url'], params=params, credential=self.credential)
 
-
     async def ban_user(self, uid: int):
         """
         封禁用户
@@ -285,7 +282,6 @@ class LiveRoom:
             "visit_id": ""
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
-
 
     async def unban_user(self, block_id: int):
         """
@@ -342,15 +338,15 @@ class LiveRoom:
         return await request(api['method'], api["url"], data=data, credential=self.credential)
 
     async def send_gift_from_bag(self,
-                        uid: int,
-                        bag_id: int,
-                        gift_id: int,
-                        gift_num: int,
-                        platform: str = "pc",
-                        send_ruid: int = 0,
-                        storm_beat_id: int = 0,
-                        price: int = 0,
-                        biz_code: str = "live"):
+                                 uid: int,
+                                 bag_id: int,
+                                 gift_id: int,
+                                 gift_num: int,
+                                 platform: str = "pc",
+                                 send_ruid: int = 0,
+                                 storm_beat_id: int = 0,
+                                 price: int = 0,
+                                 biz_code: str = "live"):
         """
         赠送包裹中的礼物，获取包裹信息可以使用 get_self_bag 方法
 
@@ -415,14 +411,14 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], params=params, credential=self.credential)
 
-    async def get_gift_common(self, area_id: int="",area_parent_id: int=""):
+    async def get_gift_common(self, area_id: int = "", area_parent_id: int = ""):
         """
         获取当前直播间内的通用礼物列表
 
         Args:
             area_id (int, optional): 子分区id. Defaults to None
             area_parent_id (int, optional): 父分区id. Defaults to None
-        
+
         """
         api = API["info"]["gift_common"]
         params = {
@@ -434,13 +430,13 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], params=params, credential=self.credential)
 
-    async def get_gift_special(self, tab_id: int,area_id: int="",area_parent_id: int=""):
+    async def get_gift_special(self, tab_id: int, area_id: int = "", area_parent_id: int = ""):
         """
         获取当前直播间内的特殊礼物列表
 
         Args:
             tab_id (int) : 特权礼物:2  , 定制礼物:3
-        
+
         """
         api = API["info"]["gift_special"]
         params = {
@@ -453,18 +449,16 @@ class LiveRoom:
             "build": 1
         }
         return await request(api['method'], api["url"], params=params, credential=self.credential)
-    
 
-    
     async def send_gift_gold(self,
-                        uid: int,
-                        gift_id: int,
-                        gift_num: int,
-                        price: int,
-                        platform: str = "pc",
-                        send_ruid: int = 0,
-                        storm_beat_id: int = 0,
-                        biz_code: str = "live"):
+                             uid: int,
+                             gift_id: int,
+                             gift_num: int,
+                             price: int,
+                             platform: str = "pc",
+                             send_ruid: int = 0,
+                             storm_beat_id: int = 0,
+                             biz_code: str = "live"):
 
         """
         赠送金瓜子礼物
@@ -478,7 +472,7 @@ class LiveRoom:
         """
         self.credential.raise_for_no_sessdata()
         self.credential.raise_for_no_bili_jct()
-        
+
         api = API["operate"]["send_gift_gold"]
         data = {
             "uid": uid,
@@ -497,17 +491,16 @@ class LiveRoom:
             "visit_id": ""
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
-        
 
     async def send_gift_silver(self,
-                        uid: int,
-                        gift_id: int,
-                        gift_num: int,
-                        price: int,
-                        platform: str = "pc",
-                        send_ruid: int = 0,
-                        storm_beat_id: int = 0,
-                        biz_code: str = "live"):
+                               uid: int,
+                               gift_id: int,
+                               gift_num: int,
+                               price: int,
+                               platform: str = "pc",
+                               send_ruid: int = 0,
+                               storm_beat_id: int = 0,
+                               biz_code: str = "live"):
 
         """
         赠送银瓜子礼物
@@ -521,7 +514,7 @@ class LiveRoom:
         """
         self.credential.raise_for_no_sessdata()
         self.credential.raise_for_no_bili_jct()
-        
+
         api = API["operate"]["send_gift_silver"]
         data = {
             "uid": uid,
@@ -540,6 +533,7 @@ class LiveRoom:
             "visit_id": ""
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
+
 
 class LiveDanmaku(AsyncEvent):
     """
@@ -588,7 +582,7 @@ class LiveDanmaku(AsyncEvent):
     STATUS_ERROR = 5
 
     def __init__(self, room_display_id: int, debug: bool = False,
-                    credential: Credential = None, max_retry: int = 5, retry_after: float = 1):
+                 credential: Credential = None, max_retry: int = 5, retry_after: float = 1):
         """
         Args:
             room_display_id (int)                 : 房间展示 ID
@@ -615,7 +609,8 @@ class LiveDanmaku(AsyncEvent):
         self.logger = logging.getLogger(f"LiveDanmaku_{self.room_display_id}")
         self.logger.setLevel(logging.DEBUG if debug else logging.INFO)
         handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter("[" + str(room_display_id) + "][%(asctime)s][%(levelname)s] %(message)s"))
+        handler.setFormatter(logging.Formatter(
+            "[" + str(room_display_id) + "][%(asctime)s][%(levelname)s] %(message)s"))
         self.logger.addHandler(handler)
 
     def get_status(self):
@@ -642,7 +637,6 @@ class LiveDanmaku(AsyncEvent):
 
         await self.__main()
 
-
     async def disconnect(self):
         """
         断开连接
@@ -661,7 +655,6 @@ class LiveDanmaku(AsyncEvent):
         await self.__ws.close()
 
         self.logger.info('连接已关闭')
-
 
     async def __main(self):
         """
@@ -720,7 +713,8 @@ class LiveDanmaku(AsyncEvent):
                     await self.__send_verify_data(ws, conf['token'])
 
                     # 新建心跳任务
-                    self.__tasks.append(asyncio.create_task(self.__heartbeat(ws)))
+                    self.__tasks.append(
+                        asyncio.create_task(self.__heartbeat(ws)))
 
                     async for msg in ws:
                         if msg.type == aiohttp.WSMsgType.BINARY:
@@ -741,7 +735,8 @@ class LiveDanmaku(AsyncEvent):
                 # 正常断开情况下跳出循环
                 if self.__status != self.STATUS_CLOSED or self.err_reason:
                     # 非用户手动调用关闭，触发重连
-                    raise LiveException('非正常关闭连接' if not self.err_reason else self.err_reason)
+                    raise LiveException(
+                        '非正常关闭连接' if not self.err_reason else self.err_reason)
                 else:
                     break
 
@@ -793,8 +788,8 @@ class LiveDanmaku(AsyncEvent):
 
                 # DANMU_MSG 事件名特殊：DANMU_MSG:4:0:2:2:2:0，需取出事件名，暂不知格式
                 if callback_info["type"].find('DANMU_MSG') > -1:
-                     callback_info["type"] = 'DANMU_MSG'
-                     info["data"]["cmd"] = 'DANMU_MSG'
+                    callback_info["type"] = 'DANMU_MSG'
+                    info["data"]["cmd"] = 'DANMU_MSG'
 
                 callback_info["data"] = info["data"]
                 self.dispatch(callback_info["type"], callback_info)
@@ -805,16 +800,16 @@ class LiveDanmaku(AsyncEvent):
 
     async def __send_verify_data(self, ws: ClientWebSocketResponse, token: str):
         verifyData = {"uid": 0, "roomid": self.__room_real_id,
-                        "protover": 2, "platform": "web", "type": 2, "key": token}
+                      "protover": 2, "platform": "web", "type": 2, "key": token}
         data = json.dumps(verifyData).encode()
         await self.__send(data, self.PROTOCOL_VERSION_HEARTBEAT, self.DATAPACK_TYPE_VERIFY, ws)
-
 
     async def __heartbeat(self, ws: ClientWebSocketResponse):
         """
         定时发送心跳包
         """
-        HEARTBEAT = base64.b64decode("AAAAHwAQAAEAAAACAAAAAVtvYmplY3QgT2JqZWN0XQ==")
+        HEARTBEAT = base64.b64decode(
+            "AAAAHwAQAAEAAAACAAAAAVtvYmplY3QgT2JqZWN0XQ==")
         while True:
             if self.__heartbeat_timer == 0:
                 self.logger.debug("发送心跳包")
@@ -878,7 +873,8 @@ class LiveDanmaku(AsyncEvent):
                 recvData["data"] = json.loads(chunkData.decode())
             elif header[2] == 1:
                 if header[3] == LiveDanmaku.DATAPACK_TYPE_HEARTBEAT_RESPONSE:
-                    recvData["data"] = {"view": struct.unpack(">I", chunkData)[0]}
+                    recvData["data"] = {
+                        "view": struct.unpack(">I", chunkData)[0]}
                 elif header[3] == LiveDanmaku.DATAPACK_TYPE_VERIFY_SUCCESS_RESPONSE:
                     recvData["data"] = json.loads(chunkData.decode())
             ret.append(recvData)
@@ -907,7 +903,7 @@ async def get_self_live_info(credential: Credential):
     return await request(api['method'], api["url"], credential=credential)
 
 
-async def get_self_guards(credential: Credential, page: int = 1, page_size: int = 10):
+async def get_self_guards(page: int = 1, page_size: int = 10, credential: Credential = None):
     """
     获取自己开通的大航海信息
 
@@ -922,6 +918,8 @@ async def get_self_guards(credential: Credential, page: int = 1, page_size: int 
     pages = math.ceil(info['data']['guards'] / 10)
     ```
     """
+    if credential is None:
+        credential = Credential()
 
     credential.raise_for_no_sessdata()
 
@@ -943,15 +941,16 @@ async def get_self_bag(credential: Credential):
     api = API["info"]["bag_list"]
     return await request(api['method'], api["url"], credential=credential)
 
+
 async def get_gift_config(room_id: int = "",
-                 area_id: int="",
-                 area_parent_id: int="",
-                 platform: str="pc",
-                 source: str="live",):
+                          area_id: int = "",
+                          area_parent_id: int = "",
+                          platform: str = "pc",
+                          source: str = "live",):
     """
-    获取所有礼物的信息，包括礼物id、名称、价格、等级等。
-    同时填了room_id、area_id、area_parent_id，则返回一个较小的json，只包含该房间、该子区域、父区域的礼物。
-    但即使限定了三个条件，仍然会返回约1.5w行的json。不加限定则是2.8w行。
+    获取所有礼物的信息，包括礼物 id、名称、价格、等级等。
+    同时填了 room_id、area_id、area_parent_id，则返回一个较小的 json，只包含该房间、该子区域、父区域的礼物。
+    但即使限定了三个条件，仍然会返回约 1.5w 行的 json。不加限定则是 2.8w 行。
     """
     api = API["info"]["gift_config"]
     params = {
@@ -962,7 +961,8 @@ async def get_gift_config(room_id: int = "",
         "source": source
     }
     return await request(api['method'], api["url"], params=params)
-    
+
+
 async def get_area_info():
     """
     获取所有分区信息

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -342,19 +342,18 @@ class LiveRoom:
                                  bag_id: int,
                                  gift_id: int,
                                  gift_num: int,
-                                 platform: str = "pc",
-                                 send_ruid: int = 0,
                                  storm_beat_id: int = 0,
-                                 price: int = 0,
-                                 biz_code: str = "live"):
+                                 price: int = 0):
         """
         赠送包裹中的礼物，获取包裹信息可以使用 get_self_bag 方法
 
         Args:
-            uid (int)       : 用户 UID
-            bag_id (int)    : 礼物背包 ID
-            gift_id (int)   : 礼物 ID
-            gift_num (int)  : 礼物数量
+            uid (int)                       : 赠送用户的 UID
+            bag_id (int)                    : 礼物背包 ID
+            gift_id (int)                   : 礼物 ID
+            gift_num (int)                  : 礼物数量
+            storm_beat_id (int, optional)   : 未知， Defaults to 0
+            price (int, optional)           : 礼物单价，Defaults to 0
         """
         self.credential.raise_for_no_sessdata()
         self.credential.raise_for_no_bili_jct()
@@ -365,11 +364,11 @@ class LiveRoom:
             "bag_id": bag_id,
             "gift_id": gift_id,
             "gift_num": gift_num,
-            "platform": platform,
-            "send_ruid": send_ruid,
+            "platform": "pc",
+            "send_ruid": 0,
             "storm_beat_id": storm_beat_id,
             "price": price,
-            "biz_code": biz_code,
+            "biz_code": "live",
             "biz_id": self.room_display_id,
             "ruid": await self.__get_ruid(),
 
@@ -397,9 +396,7 @@ class LiveRoom:
         获取自己在该房间的大航海信息, 比如是否开通, 等级等
 
         Args:
-            uid (int)   : 直播者的用户id
             act_id (int) : 未知，Defaults to 100061
-
         """
         self.credential.raise_for_no_sessdata()
 
@@ -411,15 +408,17 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], params=params, credential=self.credential)
 
-    async def get_gift_common(self, area_id: int = "", area_parent_id: int = ""):
+    async def get_gift_common(self):
         """
-        获取当前直播间内的通用礼物列表
-
-        Args:
-            area_id (int, optional): 子分区id. Defaults to None
-            area_parent_id (int, optional): 父分区id. Defaults to None
-
+        获取当前直播间内的普通礼物列表
         """
+        api_room_info = API["info"]["room_info"]
+        params_room_info = {
+            "room_id": self.room_display_id,
+        }
+        res_room_info = await request(api_room_info['method'], api_room_info["url"], params=params_room_info, credential=self.credential)
+        area_id, area_parent_id = res_room_info["room_info"]["area_id"], res_room_info["room_info"]["parent_area_id"]
+
         api = API["info"]["gift_common"]
         params = {
             "room_id": self.room_display_id,
@@ -430,15 +429,22 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], params=params, credential=self.credential)
 
-    async def get_gift_special(self, tab_id: int, area_id: int = "", area_parent_id: int = ""):
+    async def get_gift_special(self, tab_id: int):
         """
         获取当前直播间内的特殊礼物列表
 
         Args:
-            tab_id (int) : 特权礼物:2  , 定制礼物:3
-
+            tab_id (int) : 2：特权礼物，3：定制礼物
         """
+        api_room_info = API["info"]["room_info"]
+        params_room_info = {
+            "room_id": self.room_display_id,
+        }
+        res_room_info = await request(api_room_info['method'], api_room_info["url"], params=params_room_info, credential=self.credential)
+        area_id, area_parent_id = res_room_info["room_info"]["area_id"], res_room_info["room_info"]["parent_area_id"]
+
         api = API["info"]["gift_special"]
+
         params = {
             "tab_id": tab_id,
             "area_id": area_id,
@@ -455,19 +461,17 @@ class LiveRoom:
                              gift_id: int,
                              gift_num: int,
                              price: int,
-                             platform: str = "pc",
-                             send_ruid: int = 0,
-                             storm_beat_id: int = 0,
-                             biz_code: str = "live"):
+                             storm_beat_id: int = 0):
 
         """
         赠送金瓜子礼物
 
         Args:
-            uid (int)       : 用户 UID
-            gift_id (int)   : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
-            gift_num (int)  : 赠送礼物数量
-            price (int)     : 礼物单价
+            uid (int)                     : 赠送用户的 UID
+            gift_id (int)                 : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
+            gift_num (int)                : 赠送礼物数量
+            price (int)                   : 礼物单价
+            storm_beat_id (int, Optional) : 未知，Defaults to 0
 
         """
         self.credential.raise_for_no_sessdata()
@@ -480,10 +484,10 @@ class LiveRoom:
             "gift_num": gift_num,
             "price": price,
             "ruid": await self.__get_ruid(),
-            "biz_code": biz_code,
+            "biz_code": "live",
             "biz_id": self.room_display_id,
-            "platform": platform,
-            "storm_beat_id": 0,
+            "platform": "pc",
+            "storm_beat_id": storm_beat_id,
             "send_ruid": 0,
             "coin_type": "gold",
             "bag_id": "0",
@@ -497,19 +501,17 @@ class LiveRoom:
                                gift_id: int,
                                gift_num: int,
                                price: int,
-                               platform: str = "pc",
-                               send_ruid: int = 0,
-                               storm_beat_id: int = 0,
-                               biz_code: str = "live"):
+                               storm_beat_id: int = 0,):
 
         """
         赠送银瓜子礼物
 
         Args:
-            uid (int)       : 用户 UID
-            gift_id (int)   : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
-            gift_num (int)  : 赠送礼物数量
-            price (int)     : 礼物单价
+            uid (int)                       : 赠送用户的 UID
+            gift_id (int)                   : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
+            gift_num (int)                  : 赠送礼物数量
+            price (int)                     : 礼物单价
+            storm_beat_id(int, Optional)    : 未知, Defaults to 0
 
         """
         self.credential.raise_for_no_sessdata()
@@ -522,13 +524,13 @@ class LiveRoom:
             "gift_num": gift_num,
             "price": price,
             "ruid": await self.__get_ruid(),
-            "biz_code": biz_code,
+            "biz_code": "live",
             "biz_id": self.room_display_id,
-            "platform": platform,
-            "storm_beat_id": 0,
+            "platform": "pc",
+            "storm_beat_id": storm_beat_id,
             "send_ruid": 0,
             "coin_type": "silver",
-            "bag_id": "0",
+            "bag_id": 0,
             "rnd": int(time.time()),
             "visit_id": ""
         }
@@ -942,23 +944,26 @@ async def get_self_bag(credential: Credential):
     return await request(api['method'], api["url"], credential=credential)
 
 
-async def get_gift_config(room_id: int = "",
-                          area_id: int = "",
-                          area_parent_id: int = "",
-                          platform: str = "pc",
-                          source: str = "live",):
+async def get_gift_config(room_id: str = "",
+                          area_id: str = "",
+                          area_parent_id: str = ""):
     """
     获取所有礼物的信息，包括礼物 id、名称、价格、等级等。
     同时填了 room_id、area_id、area_parent_id，则返回一个较小的 json，只包含该房间、该子区域、父区域的礼物。
     但即使限定了三个条件，仍然会返回约 1.5w 行的 json。不加限定则是 2.8w 行。
+
+    Args:
+        room_id (str, optional)         : 房间显示id. Defaults to None.
+        area_id (str, optional)         : 子分区id. Defaults to None.
+        area_parent_id (str, optional)  : 父分区id. Defaults to None.
     """
     api = API["info"]["gift_config"]
     params = {
+        "platform": "pc",
+        "source": "live",
         "room_id": room_id,
         "area_id": area_id,
-        "area_parent_id": area_parent_id,
-        "platform": platform,
-        "source": source
+        "area_parent_id": area_parent_id
     }
     return await request(api['method'], api["url"], params=params)
 

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -341,7 +341,7 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
 
-    async def send_gift(self,
+    async def send_gift_from_bag(self,
                         uid: int,
                         bag_id: int,
                         gift_id: int,
@@ -352,7 +352,7 @@ class LiveRoom:
                         price: int = 0,
                         biz_code: str = "live"):
         """
-        直播间发送礼物
+        赠送包裹中的礼物，获取包裹信息可以使用 get_self_bag 方法
 
         Args:
             uid (int)       : 用户 UID
@@ -363,7 +363,7 @@ class LiveRoom:
         self.credential.raise_for_no_sessdata()
         self.credential.raise_for_no_bili_jct()
 
-        api = API["operate"]["send_gift"]
+        api = API["operate"]["send_gift_from_bag"]
         data = {
             "uid": uid,
             "bag_id": bag_id,
@@ -396,7 +396,7 @@ class LiveRoom:
         }
         return await request(api['method'], api["url"], data=data, credential=self.credential)
 
-    async def get_general_info(self, uid: int, act_id: int = 100061):
+    async def get_general_info(self, act_id: int = 100061):
         """
         获取自己在该房间的大航海信息, 比如是否开通, 等级等
 
@@ -405,15 +405,141 @@ class LiveRoom:
             act_id (int) : 未知，Defaults to 100061
 
         """
-        uid = (await self.get_room_play_info())["uid"]
+        self.credential.raise_for_no_sessdata()
+
         api = API["info"]["general_info"]
         params = {
             "actId": act_id,
             "roomId": self.room_display_id,
-            "uid": uid
+            "uid": await self.__get_ruid()
         }
         return await request(api['method'], api["url"], params=params, credential=self.credential)
 
+    async def get_gift_common(self, area_id: int="",area_parent_id: int=""):
+        """
+        获取当前直播间内的通用礼物列表
+
+        Args:
+            area_id (int, optional): 子分区id. Defaults to None
+            area_parent_id (int, optional): 父分区id. Defaults to None
+        
+        """
+        api = API["info"]["gift_common"]
+        params = {
+            "room_id": self.room_display_id,
+            "area_id": area_id,
+            "area_parent_id": area_parent_id,
+            "platform": "pc",
+            "source": "live"
+        }
+        return await request(api['method'], api["url"], params=params, credential=self.credential)
+
+    async def get_gift_special(self, tab_id: int,area_id: int="",area_parent_id: int=""):
+        """
+        获取当前直播间内的特殊礼物列表
+
+        Args:
+            tab_id (int) : 特权礼物:2  , 定制礼物:3
+        
+        """
+        api = API["info"]["gift_special"]
+        params = {
+            "tab_id": tab_id,
+            "area_id": area_id,
+            "area_parent_id": area_parent_id,
+            "room_id": await self.__get_ruid(),
+            "source": "live",
+            "platform": "pc",
+            "build": 1
+        }
+        return await request(api['method'], api["url"], params=params, credential=self.credential)
+    
+
+    
+    async def send_gift_gold(self,
+                        uid: int,
+                        gift_id: int,
+                        gift_num: int,
+                        price: int,
+                        platform: str = "pc",
+                        send_ruid: int = 0,
+                        storm_beat_id: int = 0,
+                        biz_code: str = "live"):
+
+        """
+        赠送金瓜子礼物
+
+        Args:
+            uid (int)       : 用户 UID
+            gift_id (int)   : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
+            gift_num (int)  : 赠送礼物数量
+            price (int)     : 礼物单价
+
+        """
+        self.credential.raise_for_no_sessdata()
+        self.credential.raise_for_no_bili_jct()
+        
+        api = API["operate"]["send_gift_gold"]
+        data = {
+            "uid": uid,
+            "gift_id": gift_id,
+            "gift_num": gift_num,
+            "price": price,
+            "ruid": await self.__get_ruid(),
+            "biz_code": biz_code,
+            "biz_id": self.room_display_id,
+            "platform": platform,
+            "storm_beat_id": 0,
+            "send_ruid": 0,
+            "coin_type": "gold",
+            "bag_id": "0",
+            "rnd": int(time.time()),
+            "visit_id": ""
+        }
+        return await request(api['method'], api["url"], data=data, credential=self.credential)
+        
+
+    async def send_gift_silver(self,
+                        uid: int,
+                        gift_id: int,
+                        gift_num: int,
+                        price: int,
+                        platform: str = "pc",
+                        send_ruid: int = 0,
+                        storm_beat_id: int = 0,
+                        biz_code: str = "live"):
+
+        """
+        赠送银瓜子礼物
+
+        Args:
+            uid (int)       : 用户 UID
+            gift_id (int)   : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
+            gift_num (int)  : 赠送礼物数量
+            price (int)     : 礼物单价
+
+        """
+        self.credential.raise_for_no_sessdata()
+        self.credential.raise_for_no_bili_jct()
+        
+        api = API["operate"]["send_gift_silver"]
+        data = {
+            "uid": uid,
+            "gift_id": gift_id,
+            "gift_num": gift_num,
+            "price": price,
+            "ruid": await self.__get_ruid(),
+            "biz_code": biz_code,
+            "biz_id": self.room_display_id,
+            "platform": platform,
+            "storm_beat_id": 0,
+            "send_ruid": 0,
+            "coin_type": "silver",
+            "bag_id": "0",
+            "rnd": int(time.time()),
+            "visit_id": ""
+        }
+        return await request(api['method'], api["url"], data=data, credential=self.credential)
 
 class LiveDanmaku(AsyncEvent):
     """
@@ -816,3 +942,30 @@ async def get_self_bag(credential: Credential):
 
     api = API["info"]["bag_list"]
     return await request(api['method'], api["url"], credential=credential)
+
+async def get_gift_config(room_id: int = "",
+                 area_id: int="",
+                 area_parent_id: int="",
+                 platform: str="pc",
+                 source: str="live",):
+    """
+    获取所有礼物的信息，包括礼物id、名称、价格、等级等。
+    同时填了room_id、area_id、area_parent_id，则返回一个较小的json，只包含该房间、该子区域、父区域的礼物。
+    但即使限定了三个条件，仍然会返回约1.5w行的json。不加限定则是2.8w行。
+    """
+    api = API["info"]["gift_config"]
+    params = {
+        "room_id": room_id,
+        "area_id": area_id,
+        "area_parent_id": area_parent_id,
+        "platform": platform,
+        "source": source
+    }
+    return await request(api['method'], api["url"], params=params)
+    
+async def get_area_info():
+    """
+    获取所有分区信息
+    """
+    api = API["info"]["area_info"]
+    return await request(api['method'], api["url"])

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -467,11 +467,11 @@ class LiveRoom:
         赠送金瓜子礼物
 
         Args:
-            uid (int)                     : 赠送用户的 UID
-            gift_id (int)                 : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
-            gift_num (int)                : 赠送礼物数量
-            price (int)                   : 礼物单价
-            storm_beat_id (int, Optional) : 未知，Defaults to 0
+            uid           (int)          : 赠送用户的 UID
+            gift_id       (int)          : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
+            gift_num      (int)          : 赠送礼物数量
+            price         (int)          : 礼物单价
+            storm_beat_id (int, Optional): 未知，Defaults to 0
 
         """
         self.credential.raise_for_no_sessdata()
@@ -507,11 +507,11 @@ class LiveRoom:
         赠送银瓜子礼物
 
         Args:
-            uid (int)                       : 赠送用户的 UID
-            gift_id (int)                   : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
-            gift_num (int)                  : 赠送礼物数量
-            price (int)                     : 礼物单价
-            storm_beat_id(int, Optional)    : 未知, Defaults to 0
+            uid           (int)          : 赠送用户的 UID
+            gift_id       (int)          : 礼物 ID (可以通过 get_gift_common 或 get_gift_special 或 get_gift_config 获取)
+            gift_num      (int)          : 赠送礼物数量
+            price         (int)          : 礼物单价
+            storm_beat_id (int, Optional): 未知, Defaults to 0
 
         """
         self.credential.raise_for_no_sessdata()
@@ -905,17 +905,19 @@ async def get_self_live_info(credential: Credential):
     return await request(api['method'], api["url"], credential=credential)
 
 
-async def get_self_guards(page: int = 1, page_size: int = 10, credential: Credential = None):
+async def get_self_dahanghai_info(page: int = 1, page_size: int = 10, credential: Credential = None):
     """
     获取自己开通的大航海信息
 
     Args:
-        page (int, optional): 页数. Defaults to 1.
+        page      (int, optional): 页数. Defaults to 1.
         page_size (int, optional): 每页数量. Defaults to 10.
 
     总页数取得方法:
 
     ```python
+    import math
+
     info = live.get_self_live_info(credential)
     pages = math.ceil(info['data']['guards'] / 10)
     ```
@@ -944,26 +946,26 @@ async def get_self_bag(credential: Credential):
     return await request(api['method'], api["url"], credential=credential)
 
 
-async def get_gift_config(room_id: str = "",
-                          area_id: str = "",
-                          area_parent_id: str = ""):
+async def get_gift_config(room_id: int = None,
+                          area_id: int = None,
+                          area_parent_id: int = None):
     """
     获取所有礼物的信息，包括礼物 id、名称、价格、等级等。
     同时填了 room_id、area_id、area_parent_id，则返回一个较小的 json，只包含该房间、该子区域、父区域的礼物。
     但即使限定了三个条件，仍然会返回约 1.5w 行的 json。不加限定则是 2.8w 行。
 
     Args:
-        room_id (str, optional)         : 房间显示id. Defaults to None.
-        area_id (str, optional)         : 子分区id. Defaults to None.
-        area_parent_id (str, optional)  : 父分区id. Defaults to None.
+        room_id (int, optional)         : 房间显示id. Defaults to None.
+        area_id (int, optional)         : 子分区id. Defaults to None.
+        area_parent_id (int, optional)  : 父分区id. Defaults to None.
     """
     api = API["info"]["gift_config"]
     params = {
         "platform": "pc",
         "source": "live",
-        "room_id": room_id,
-        "area_id": area_id,
-        "area_parent_id": area_parent_id
+        "room_id": room_id if room_id is not None else "",
+        "area_id": area_id if area_id is not None else "",
+        "area_parent_id": area_parent_id if area_parent_id is not None else ""
     }
     return await request(api['method'], api["url"], params=params)
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -66,7 +66,7 @@ async def test_p_sign_up_dahanghai():
     return await l.sign_up_dahanghai()
 
 async def test_q_send_gift():
-    return await l.send_gift(5702480, 254617846, 30725, 1)
+    return await l.send_gift(5702480, 254667454, 30607, 1)
 
 async def test_r_receive_reward():
     return await l.receive_reward(2)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,57 +1,73 @@
 from bilibili_api.utils.Danmaku import Danmaku
 from bilibili_api import live
+from bilibili_api.exceptions import ResponseCodeException
 from .common import get_credential
 import random
 
 l = live.LiveRoom(22544798, get_credential())
 
+
 async def test_a_get_room_info():
     return await l.get_room_info()
+
 
 async def test_b_get_room_play_info():
     return await l.get_room_play_info()
 
+
 async def test_c_get_room_play_info_v2():
     return await l.get_room_play_info_v2()
+
 
 async def test_d_get_room_play_url():
     return await l.get_room_play_url()
 
+
 async def test_e_get_user_info_in_room():
     return await l.get_user_info_in_room()
+
 
 async def test_f_get_dahanghai():
     return await l.get_dahanghai()
 
+
 async def test_g_get_serven_rank():
     return await l.get_seven_rank()
+
 
 async def test_h_get_fans_medal_rank():
     return await l.get_fans_medal_rank()
 
+
 async def test_i_get_self_info():
     return await live.get_self_info(get_credential())
 
+
 async def test_j_get_chat_conf():
     return await l.get_chat_conf()
+
 
 async def test_k_ban_user():
     return await l.ban_user(1)
 
 black_list = None
 
+
 async def test_l_get_black_list():
     global black_list
     black_list = await l.get_black_list()
     return black_list
+
 
 async def test_m_unban_user():
     for item in black_list["data"]:
         if item["tuid"] == 1:
             return await l.unban_user(item["id"])
 
+
 async def test_n_send_danmaku():
     return await l.send_danmaku(Danmaku(f'test_{random.randint(10000, 99999)}'))
+
 
 async def test_o_LiveDanmaku():
     async def on_msg(data):
@@ -62,41 +78,66 @@ async def test_o_LiveDanmaku():
     room.add_event_listener('ALL', on_msg)
     await room.connect()
 
+
 async def test_p_sign_up_dahanghai():
     return await l.sign_up_dahanghai()
+
 
 async def test_q_send_gift_from_bag():
     return await l.send_gift_from_bag(5702480, 255051127, 30607, 1)
 
+
 async def test_r_receive_reward():
     return await l.receive_reward(2)
+
 
 async def test_s_get_general_info():
     return await l.get_general_info()
 
+
 async def test_t_get_self_live_info():
     return await live.get_self_live_info(get_credential())
 
+
 async def test_u_get_self_guards():
-    return await live.get_self_guards(get_credential())
+    return await live.get_self_guards(credential=get_credential())
+
 
 async def test_v_get_self_bag():
     return await live.get_self_bag(get_credential())
 
+
 async def test_w_get_gift_config():
     return await live.get_gift_config()
+
 
 async def test_x_get_gift_common():
     return await l.get_gift_common()
 
+
 async def test_y_get_gift_sepcial():
     return await l.get_gift_special(tab_id=2)
 
+
 async def test_z_send_gift_gold():
-    return await l.send_gift_gold(5702480,31060,1,100)
+    try:
+        return await l.send_gift_gold(5702480, 31060, 1, 100)
+    except ResponseCodeException as e:
+        if e.code == 200013:
+            # 余额不足，忽略
+            return e.raw
+        raise e
 
-async def test_aa_send_gift_silver():
-    return await l.send_gift_silver(5702480,1,1,100)
 
-async def test_ab_get_area_info():
+async def test_za_send_gift_silver():
+    try:
+        return await l.send_gift_silver(5702480, 1, 1, 100)
+    except ResponseCodeException as e:
+        if e.code == 200013:
+            # 余额不足，忽略
+            return e.raw
+        raise e
+
+
+async def test_zb_get_area_info():
     return await live.get_area_info()

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -65,14 +65,14 @@ async def test_o_LiveDanmaku():
 async def test_p_sign_up_dahanghai():
     return await l.sign_up_dahanghai()
 
-async def test_q_send_gift():
-    return await l.send_gift(5702480, 254667454, 30607, 1)
+async def test_q_send_gift_from_bag():
+    return await l.send_gift_from_bag(5702480, 255051127, 30607, 1)
 
 async def test_r_receive_reward():
     return await l.receive_reward(2)
 
 async def test_s_get_general_info():
-    return await l.get_general_info(660303135)
+    return await l.get_general_info()
 
 async def test_t_get_self_live_info():
     return await live.get_self_live_info(get_credential())
@@ -82,3 +82,21 @@ async def test_u_get_self_guards():
 
 async def test_v_get_self_bag():
     return await live.get_self_bag(get_credential())
+
+async def test_w_get_gift_config():
+    return await live.get_gift_config()
+
+async def test_x_get_gift_common():
+    return await l.get_gift_common()
+
+async def test_y_get_gift_sepcial():
+    return await l.get_gift_special(tab_id=2)
+
+async def test_z_send_gift_gold():
+    return await l.send_gift_gold(5702480,31060,1,100)
+
+async def test_aa_send_gift_silver():
+    return await l.send_gift_silver(5702480,1,1,100)
+
+async def test_ab_get_area_info():
+    return await live.get_area_info()

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -84,7 +84,13 @@ async def test_p_sign_up_dahanghai():
 
 
 async def test_q_send_gift_from_bag():
-    return await l.send_gift_from_bag(5702480, 255051127, 30607, 1)
+    try:
+
+        return await l.send_gift_from_bag(5702480, 255051127, 30607, 1)
+    except ResponseCodeException as e:
+        if e.code != 200161:
+            raise e
+        return e.raw
 
 
 async def test_r_receive_reward():
@@ -100,7 +106,7 @@ async def test_t_get_self_live_info():
 
 
 async def test_u_get_self_guards():
-    return await live.get_self_guards(credential=get_credential())
+    return await live.get_self_dahanghai_info(credential=get_credential())
 
 
 async def test_v_get_self_bag():

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -62,3 +62,23 @@ async def test_o_LiveDanmaku():
     room.add_event_listener('ALL', on_msg)
     await room.connect()
 
+async def test_p_sign_up_dahanghai():
+    return await l.sign_up_dahanghai()
+
+async def test_q_send_gift():
+    return await l.send_gift(5702480, 254617846, 30725, 1)
+
+async def test_r_receive_reward():
+    return await l.receive_reward(2)
+
+async def test_s_get_general_info():
+    return await l.get_general_info(660303135)
+
+async def test_t_get_self_live_info():
+    return await live.get_self_live_info(get_credential())
+
+async def test_u_get_self_guards():
+    return await live.get_self_guards(get_credential())
+
+async def test_v_get_self_bag():
+    return await live.get_self_bag(get_credential())


### PR DESCRIPTION
增加了一些直播相关的功能，包括大航海签到、直播赠送礼物、领取航海日志奖励、获取航海信息、获取自己开通的大航海列表、获取礼物包裹等


以下为`test_live.py`中新增的项目，`send_gift`的参数都需要改一下才能跑
我自己的测试报告: [github action](https://github.com/bakashigure/bilibili-api/actions/runs/1260531844)
```
async def test_p_sign_up_dahanghai():
    return await l.sign_up_dahanghai()

async def test_q_send_gift():
    return await l.send_gift(5702480, 254617846,30725,1)

async def test_r_receive_reward():
    return await l.receive_reward(2)

async def test_s_get_general_info():
    return await l.get_general_info(660303135)

async def test_t_get_self_live_info():
    return await live.get_self_live_info(get_credential())

async def test_u_get_self_guards():
    return await live.get_self_guards(get_credential())

async def test_v_get_self_bag():
    return await live.get_self_bag(get_credential())
```