### PR TITLE
新增获取关注列表直播状态接口

### DIFF
--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -208,6 +208,26 @@
         "area_parent_id": "int: 父分区 ID 可以不用填, 获取分区id可使用 get_area_info 方法"
       },
       "comment":"获取所有礼物信息，三个字段可以不用填，但填了有助于减小返回内容的大小，置空返回约 2.7w 行，填了三个对应值返回约 1.4w 行"
+    },
+    "followers_live_info":{
+      "url": "https://api.live.bilibili.com/xlive/app-interface/v1/relation/liveAnchor",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "filterRule": "int: 0 ,未知",
+        "need_recommend": "int: 是否接受推荐直播间, 0为不接受, 1为接受"
+      },
+      "comment": "获取关注列表中正在直播的直播间信息, 包括房间直播热度, 房间名称及标题, 清晰度, 是否官方认证等信息."
+    },
+    "followers_unlive_info":{
+      "url": "https://api.live.bilibili.com/xlive/app-interface/v1/relation/unliveAnchor",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "page": "int: 页码",
+        "pagesize": "每页数量，过多可能报错 默认：30"
+      },
+      "comment": "获取关注列表中未在直播的直播间信息, 包括上次开播时间, 上次开播的类别, 直播间公告, 是否有录播等."
     }
   },
   "operate": {

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -1012,3 +1012,40 @@ async def get_area_info():
     """
     api = API["info"]["area_info"]
     return await request(api['method'], api["url"])
+
+async def get_live_followers_info(need_recommand: int = 0, credential: Credential=None):
+    """
+    获取关注列表中正在直播的直播间信息，包括房间直播热度，房间名称及标题，清晰度，是否官方认证等信息。
+    Args:
+        need_recommand (int, optional) : 是否接受推荐直播间，Defaults to 0
+    """
+    if credential is None:
+        credential = Credential()
+
+    credential.raise_for_no_sessdata()
+
+    api = API["info"]["followers_live_info"]
+    params = {
+        "need_recommend": need_recommand,
+        "filterRule": 0
+    }
+    return await request(api['method'], api["url"], params=params, credential=credential)
+
+async def get_unlive_followers_info(page:int, page_size:int=30, credential: Credential=None):
+    """
+    获取关注列表中未在直播的直播间信息，包括上次开播时间，上次开播的类别，直播间公告，是否有录播等。
+    Args:
+        page (int, optional) : 页码
+        page_size (int, optional) : 每页数量 Defaults to 30.
+    """
+    if credential is None:
+        credential = Credential()
+        
+    credential.raise_for_no_sessdata()
+
+    api = API["info"]["followers_unlive_info"]
+    params = {
+        "page": page,
+        "pagesize": page_size,
+    }
+    return await request(api['method'], api["url"], params=params, credential=credential)

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -1013,11 +1013,12 @@ async def get_area_info():
     api = API["info"]["area_info"]
     return await request(api['method'], api["url"])
 
-async def get_live_followers_info(need_recommand: int = 0, credential: Credential=None):
+async def get_live_followers_info(need_recommend: bool = True, credential: Credential = None):
     """
     获取关注列表中正在直播的直播间信息，包括房间直播热度，房间名称及标题，清晰度，是否官方认证等信息。
+
     Args:
-        need_recommand (int, optional) : 是否接受推荐直播间，Defaults to 0
+        need_recommend (bool, optional): 是否接受推荐直播间，Defaults to True
     """
     if credential is None:
         credential = Credential()
@@ -1026,21 +1027,22 @@ async def get_live_followers_info(need_recommand: int = 0, credential: Credentia
 
     api = API["info"]["followers_live_info"]
     params = {
-        "need_recommend": need_recommand,
+        "need_recommend": int(need_recommend),
         "filterRule": 0
     }
     return await request(api['method'], api["url"], params=params, credential=credential)
 
-async def get_unlive_followers_info(page:int, page_size:int=30, credential: Credential=None):
+async def get_unlive_followers_info(page: int = 1, page_size: int = 30, credential: Credential = None):
     """
     获取关注列表中未在直播的直播间信息，包括上次开播时间，上次开播的类别，直播间公告，是否有录播等。
+
     Args:
-        page (int, optional) : 页码
-        page_size (int, optional) : 每页数量 Defaults to 30.
+        page      (int, optional): 页码, Defaults to 1.
+        page_size (int, optional): 每页数量 Defaults to 30.
     """
     if credential is None:
         credential = Credential()
-        
+
     credential.raise_for_no_sessdata()
 
     api = API["info"]["followers_unlive_info"]

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -151,3 +151,8 @@ async def test_zb_get_area_info():
 async def test_zc_get_gaonengbang():
     return await l.get_gaonengbang()
 
+async def test_zc_get_live_followers_info():
+    return await live.get_live_followers_info(credential=get_credential())
+
+async def test_zd_get_unlive_followers_info():
+    return await live.get_unlive_followers_info(page=1, credential=get_credential())


### PR DESCRIPTION
新增获取关注列表直播状态接口，
`get_live_followers_info` 为关注列表中正在直播的，可获取直播间热度、房间名称标题、清晰度、是否官方认证等。
`get_unlive_followers_info` 为关注列表中没开播的，可获取上次直播时间、上次直播类别、是否有录播等。

麻了，第一次写在v8分支上去了(