### PR TITLE
Fixed: #262

### DIFF
--- a/bilibili_api/video.py
+++ b/bilibili_api/video.py
@@ -213,7 +213,8 @@ class Video:
             raise ArgsException("分 p 号必须大于或等于 0。")
 
         info = await self.__get_info_cached()
-        pages = info["pages"]
+        if("pages" in info.keys()):
+            pages = info["pages"]
 
         if len(pages) <= page_index:
             raise ArgsException("不存在该分 p。")


### PR DESCRIPTION
  title: 【漏洞】获取弹幕时使用的一个API接口解析出错
  Author: hyhAsma
  description:
     ```
Python 版本： 3.8

模块版本： bilibili-api 9.1.0

运行环境： Windows 10

模块路径： bilibili_api.video

**报错信息：
File "C:\Users\ASUS\anaconda3\lib\site-packages\bilibili_api\video.py", line 218, in __get_page_id_by_index
pages = info["pages"]

报错代码：
        if page_index < 0:
            raise ArgsException("分 p 号必须大于或等于 0。")

        info = await self.__get_info_cached()
        pages = info["pages"]
本人python新手，在下载B站柯南全季弹幕时，代码跑到了889集之后，在890集以及之后进行了报错
     ```
  Date:2021/12/1
  fixed Date: 2021/12/6